### PR TITLE
Fix ApiResponse enum typo

### DIFF
--- a/src/common/enums/ApiResponse.ts
+++ b/src/common/enums/ApiResponse.ts
@@ -1,5 +1,5 @@
 export enum ApiResponseEnum {
-    StatusSuccess='sucess',
+    StatusSuccess='success',
     StatusFailed='failed',
 }
 


### PR DESCRIPTION
## Summary
- fix typo in ApiResponseEnum enum value

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68873ab867608332b325e21ff920f7a2