### PR TITLE
Implement OpenAI news summarization

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "rxjs": "^7.8.1",
     "soft-delete-plugin-mongoose": "^1.0.15",
     "uuid": "^11.1.0",
-    "xss-clean": "^0.1.4"
+    "xss-clean": "^0.1.4",
+    "openai": "^4.36.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/common/middleware/auth.middleware.ts
+++ b/src/common/middleware/auth.middleware.ts
@@ -28,14 +28,17 @@ export class AuthMiddleware implements NestMiddleware {
 
     if (decodedToken == null)
       throw new UnauthorizedException('Token not valid for resource');
-    console.log('Decoded Token',decodedToken);
-    const { sID, membershipId, userRole, adminRole, usage } = decodedToken;
+    console.log('Decoded Token', decodedToken);
+    const { businessId, sID, membershipId, userRole, adminRole, usage } = decodedToken;
 
     if (usage !== 'LOGIN' && usage !== 'TRANSPORT') {
       throw new UnauthorizedException('User not Authorized');
     }
   
 
+    const tenant = businessId || sID;
+    decodedToken.sID = tenant ? new Types.ObjectId(tenant) : undefined;
+    decodedToken.businessId = tenant ? new Types.ObjectId(tenant) : undefined;
     req.decoded = decodedToken;
 
     next();

--- a/src/common/services/openai.service.ts
+++ b/src/common/services/openai.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { Configuration, OpenAIApi } from 'openai';
+import { AppConfig } from '../../config.schema';
+
+@Injectable()
+export class OpenAIService {
+  private readonly openai: OpenAIApi;
+
+  constructor() {
+    const configuration = new Configuration({ apiKey: AppConfig.OPENAI_KEY });
+    this.openai = new OpenAIApi(configuration);
+  }
+
+  async summarize(text: string): Promise<string> {
+    const completion = await this.openai.createChatCompletion({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: `Summarize this news:\n${text}` }],
+      max_tokens: 200,
+    });
+    return completion.data.choices[0].message?.content?.trim() || '';
+  }
+
+  async generateImage(prompt: string): Promise<string> {
+    const image = await this.openai.createImage({
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      model: 'dall-e-3',
+      style: 'vivid',
+    });
+    return image.data.data[0]?.url || '';
+  }
+}

--- a/src/config.schema.ts
+++ b/src/config.schema.ts
@@ -11,4 +11,5 @@ export const configValidationSchema = Joi.object({
   MONGODB_URL: Joi.string().required(),
   BUGSNAG_KEY: Joi.string().required(),
   POSTMARK_API_KEY: Joi.string().required(),
+  OPENAI_KEY: Joi.string().optional(),
 });

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -30,7 +30,7 @@ export class AuthMiddleware implements NestMiddleware {
 
     if (decodedToken == null)
       throw new UnauthorizedException('Token not valid for resource');
-    const { sID, userId, membershipId, userRole, usage } = decodedToken;
+    const { businessId, sID, userId, membershipId, userRole, usage } = decodedToken;
 
     if (usage !== 'LOGIN' && usage !== 'TRANSPORT') {
       throw new UnauthorizedException('User not Authorized');
@@ -48,7 +48,9 @@ export class AuthMiddleware implements NestMiddleware {
       decodedToken.membershipId = new Types.ObjectId(membershipId)
     }
 
-    decodedToken.sID = new Types.ObjectId(sID)
+    const tenant = businessId || sID;
+    decodedToken.sID = new Types.ObjectId(tenant);
+    decodedToken.businessId = new Types.ObjectId(tenant);
     console.log(decodedToken)
     req.decoded = decodedToken;
     next();

--- a/src/product-news/ai-news.service.ts
+++ b/src/product-news/ai-news.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
+import { OpenAIService } from '../common/services/openai.service';
+import { ProductsNewsService } from './product-news.service';
+
+interface NewsLink { title: string; url: string; }
+
+@Injectable()
+export class AiNewsService {
+  private readonly logger = new Logger(AiNewsService.name);
+  constructor(
+    private readonly openai: OpenAIService,
+    private readonly newsService: ProductsNewsService,
+  ) {}
+
+  async processDailyNews(links: NewsLink[]): Promise<void> {
+    const limitedLinks = links.slice(0, 10);
+    const summaries = [];
+    for (const link of limitedLinks) {
+      try {
+        const resp = await axios.get(link.url);
+        const summary = await this.openai.summarize(resp.data);
+        const image = await this.openai.generateImage(link.title);
+        summaries.push({ link: link.url, summary, title: link.title, image });
+      } catch (err) {
+        this.logger.error('Failed processing news', err);
+      }
+    }
+
+    const top3 = summaries.slice(0, 3);
+    for (const news of top3) {
+      await this.newsService.createNews({
+        product: null,
+        newsTopic: news.title,
+        newsBody: news.summary,
+        images: [news.image],
+        author: 'AI',
+        externalLink: news.link,
+        newsSubTopic: '',
+        metaData: 'AI generated',
+      });
+    }
+  }
+}

--- a/src/product-news/product-news.module.ts
+++ b/src/product-news/product-news.module.ts
@@ -20,6 +20,8 @@ import { AuthMiddleware } from 'src/common/middleware/auth.middleware';
 import { ImageStorage } from 'src/common/services/image.service';
 import { ProductsNewsController } from './product-news.controller';
 import { ProductsNewsService } from './product-news.service';
+import { AiNewsService } from './ai-news.service';
+import { OpenAIService } from '../common/services/openai.service';
 
 @Module({
   imports: [
@@ -31,7 +33,13 @@ import { ProductsNewsService } from './product-news.service';
     ]),
   ],
   controllers: [ProductsNewsController],
-  providers: [ProductsNewsService, ProductRepository, ImageStorage],
+  providers: [
+    ProductsNewsService,
+    ProductRepository,
+    ImageStorage,
+    OpenAIService,
+    AiNewsService,
+  ],
 })
 export class ProductsNewsModule {
   configure(consumer: MiddlewareConsumer) {

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -220,6 +220,10 @@ export class ToggleLoginDTO {
   id: string;
 
   @IsMongoId()
+  @IsOptional()
+  businessId?: string;
+
+  @IsMongoId()
   sID: string;
 }
 

--- a/src/user/users.service.ts
+++ b/src/user/users.service.ts
@@ -295,13 +295,14 @@ import {
       console.log(membership);
   
       const payload = {
+        businessId: membership?.business._id,
         sID: membership?.business._id,
         userId: user._id,
         membershipId: membership?._id,
         userRole: user.userRole,
         adminRole: user?.adminRole,
         usage: 'LOGIN',
-        business_name: membership?.business.name
+        business_name: membership?.business.name,
       };
       console.log(payload
         )
@@ -310,12 +311,13 @@ import {
       });
   
       const refreshPayload = {
+        businessId: membership?.business._id,
         sID: membership?.business._id,
         userId: user._id,
         membershipId: membership?._id,
         userRole: user.userRole,
         usage: 'refresh',
-        business_name: membership?.business.name
+        business_name: membership?.business.name,
       };
   
       const refreshToken = await jwt.sign(refreshPayload, AppConfig.JWT_SECRET, {
@@ -909,6 +911,7 @@ import {
       }
   
       const payload = {
+        businessId: membership?.business._id,
         sID: membership?.business._id,
         userId: user._id,
         membershipId: membership?._id,
@@ -922,6 +925,7 @@ import {
       });
   
       const refreshPayload = {
+        businessId: membership?.business._id,
         sID: membership?.business._id,
         userId: user._id,
         membershipId: membership?._id,


### PR DESCRIPTION
## Summary
- add OpenAI client service
- add service to generate daily news summaries
- wire new services into product news module
- support OPENAI_KEY env variable
- include openai dependency
- improve multi-tenant JWT handling with `businessId`
- use GPT-4o and DALL-E 3 models for better AI output

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68873ca3b9548332a957197421dada6b