### PR TITLE
Fix OpenAI response parsing

### DIFF
--- a/src/common/services/openai.service.ts
+++ b/src/common/services/openai.service.ts
@@ -16,7 +16,7 @@ export class OpenAIService {
       messages: [{ role: 'user', content: `Summarize this news:\n${text}` }],
       max_tokens: 200,
     });
-    return completion.data.choices[0].message?.content?.trim() || '';
+    return completion.choices[0].message?.content?.trim() || '';
   }
 
   async generateImage(prompt: string): Promise<string> {
@@ -27,6 +27,6 @@ export class OpenAIService {
       model: 'dall-e-3',
       style: 'vivid',
     });
-    return image.data[0]?.url || '';
+    return image.data?.[0]?.url || '';
   }
 }


### PR DESCRIPTION
## Summary
- fix incorrect property access in OpenAI service

## Testing
- `npx eslint "src/**/*.ts"` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68874d78b2d88332a740f23cff3a3ed6