### PR TITLE
Add inventory summary endpoint

### DIFF
--- a/src/inventory/inventory.controller.ts
+++ b/src/inventory/inventory.controller.ts
@@ -49,6 +49,14 @@ export class InventoryController {
       return this.inventoryService.updateInventory(req.decoded, id,body, res)
 }
 
+  @Get('/summary')
+  @UseGuards(UserRolesGuard)
+  @Roles('User', 'Company')
+  getSummary(@Req() req, @Res() res: Response) {
+      const {sID} = req.decoded
+      return this.inventoryService.getSummary(sID, res)
+  }
+
 
   // Admin 
 

--- a/src/inventory/inventory.service.ts
+++ b/src/inventory/inventory.service.ts
@@ -103,6 +103,15 @@ export class InventoryService {
      }
    }
 
+   async getSummary(sID: string, res: Response) {
+      try {
+         const summary = await this.inventoryRepository.inventorySummary(sID);
+         return this.apiResponse.success(res, 'Inventories retrieved successfully', summary);
+      } catch (error) {
+         return this.apiResponse.failure(res, error.message, [], error.statusCode);
+      }
+   }
+
 
        //Admin Endpoints 
 


### PR DESCRIPTION
## Summary
- implement inventory summary endpoint guarded by `UserRolesGuard`
- support new `inventorySummary` query in repository
- expose `getSummary` method from service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find module '@nestjs/common')*

------
https://chatgpt.com/codex/tasks/task_e_68875a0fead48332b356623ee42d7977