### PR TITLE
Add unique business-product index

### DIFF
--- a/src/inventory/schema/inventorySchema.ts
+++ b/src/inventory/schema/inventorySchema.ts
@@ -72,3 +72,4 @@ export const InventorySchema = SchemaFactory.createForClass(Inventory);
 
 InventorySchema.set('toObject', { getters: true });
 InventorySchema.set('toJSON', { getters: true });
+InventorySchema.index({ businessId: 1, productId: 1 }, { unique: true });


### PR DESCRIPTION
## Summary
- speed up inventory lookups by indexing `businessId` and `productId`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68875a118dd4833297b18e54f8003936