### PR TITLE
Implement low and out of stock event logic

### DIFF
--- a/src/product-transaction/events/OutOfStockEvent copy.ts
+++ b/src/product-transaction/events/OutOfStockEvent copy.ts
@@ -1,10 +1,34 @@
 import { Injectable } from "@nestjs/common";
+import { Inventory } from "src/inventory/schema/inventorySchema";
+import { ActivityRepository } from "src/common/activity/activity.repository";
+import { PayGateService } from "src/common/services/pagate.service";
 
 @Injectable()
 export class OutOfStockEvent {
+    constructor(
+        private readonly activityRepository: ActivityRepository,
+        private readonly payGateService: PayGateService,
+    ) {}
 
+    public async execute(inventory: Inventory): Promise<void> {
+        if (!inventory) return;
 
-    public async execute(inventory)  : Promise<any> {
-        
+        if (inventory.quantityAvailable <= 0) {
+            await this.activityRepository.createActivity({
+                businessId: inventory.businessId,
+                description: `${inventory.name} is out of stock`,
+                payload: inventory,
+            });
+
+            try {
+                await this.payGateService.publishNotification({
+                    type: 'OUT_OF_STOCK',
+                    businessId: inventory.businessId,
+                    inventoryId: inventory._id,
+                });
+            } catch (e) {
+                // Notification errors should not break the flow
+            }
+        }
     }
 }

--- a/src/product-transaction/events/lowStockEvent.ts
+++ b/src/product-transaction/events/lowStockEvent.ts
@@ -1,11 +1,34 @@
 import { Injectable } from "@nestjs/common";
 import { Inventory } from "src/inventory/schema/inventorySchema";
+import { ActivityRepository } from "src/common/activity/activity.repository";
+import { PayGateService } from "src/common/services/pagate.service";
 
 @Injectable()
 export class LowStockEvent {
+    constructor(
+        private readonly activityRepository: ActivityRepository,
+        private readonly payGateService: PayGateService,
+    ) {}
 
+    public async execute(inventory: Inventory): Promise<void> {
+        if (!inventory) return;
 
-    public async execute (inventory : Inventory) : Promise<any> {
-       
+        if (inventory.quantityAvailable <= inventory.lowStockValue && inventory.quantityAvailable > 0) {
+            await this.activityRepository.createActivity({
+                businessId: inventory.businessId,
+                description: `${inventory.name} is running low on stock`,
+                payload: inventory,
+            });
+
+            try {
+                await this.payGateService.publishNotification({
+                    type: 'LOW_STOCK',
+                    businessId: inventory.businessId,
+                    inventoryId: inventory._id,
+                });
+            } catch (e) {
+                // Notification errors should not break the flow
+            }
+        }
     }
 }

--- a/src/product-transaction/product-transaction.module.ts
+++ b/src/product-transaction/product-transaction.module.ts
@@ -14,6 +14,7 @@ import { Activity, ActivitySchema } from 'src/common/activity/activity.schema';
 import { ActivityRepository } from './../common/activity/activity.repository';
 import { ProductTransactionService } from './product-transaction.service';
 import { ProductTransactionController } from './product-transaction.controller';
+import { PayGateService } from 'src/common/services/pagate.service';
 
 @Module({
     imports: [
@@ -25,7 +26,17 @@ import { ProductTransactionController } from './product-transaction.controller';
         ]), 
       ],
     controllers: [ProductTransactionController],
-    providers: [ProductTransactionService,InventoryRepository,ActivityRepository,ApiResponse, CreateTransactionAction,LowStockEvent, OutOfStockEvent, TransactionRepository]
+    providers: [
+      ProductTransactionService,
+      InventoryRepository,
+      ActivityRepository,
+      ApiResponse,
+      CreateTransactionAction,
+      LowStockEvent,
+      OutOfStockEvent,
+      TransactionRepository,
+      PayGateService,
+    ]
 })
 export class ProductTransactionModule {
   configure(consumer: MiddlewareConsumer) {


### PR DESCRIPTION
## Summary
- add activity/notification logic for low stock and out of stock events
- register PayGate service in transaction module for notifications

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing eslint deps)*

------
https://chatgpt.com/codex/tasks/task_e_68875a13925c8332bd475c0cb7b2cc84