### PR TITLE
Add unit and e2e tests for inventory service

### DIFF
--- a/test/inventory/inventory.e2e-spec.ts
+++ b/test/inventory/inventory.e2e-spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { InventoryController } from '../../src/inventory/inventory.controller';
+import { InventoryService } from '../../src/inventory/inventory.service';
+import { InventoryRepository } from '../../src/inventory/schema/inventory.repository';
+import { ActivityRepository } from '../../src/common/activity/activity.repository';
+import { ApiResponse } from '../../src/common/Helper/apiResponse';
+import { InventoryDTO } from '../../src/inventory/dto/inventoryDto';
+import { InventoryStatus } from '../../src/inventory/enum/inventoryEnum';
+
+describe('Inventory routes (e2e)', () => {
+  let app: INestApplication;
+  const inventoryRepository = {
+    createInventory: jest.fn(),
+    updateInventory: jest.fn(),
+    getAll: jest.fn(),
+  };
+  const activityRepository = { createActivity: jest.fn() };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [InventoryController],
+      providers: [
+        InventoryService,
+        { provide: InventoryRepository, useValue: inventoryRepository },
+        { provide: ActivityRepository, useValue: activityRepository },
+        ApiResponse,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use((req, _res, next) => {
+      req.decoded = { sID: 'biz', userId: 'user' };
+      next();
+    });
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /api/v1/inventory/create', () => {
+    const dto: InventoryDTO = {
+      name: 'item',
+      description: 'desc',
+      unitOfMeasure: 'kg',
+      productId: 'prod',
+      costPrice: 5,
+      sellingPrice: 10,
+      productImage: 'img',
+      status: InventoryStatus.ACTIVE,
+      lowStockValue: 1,
+      quantityAvailable: 2,
+    };
+    inventoryRepository.createInventory.mockResolvedValue({ _id: '1', ...dto });
+
+    return request(app.getHttpServer())
+      .post('/api/v1/inventory/create')
+      .send(dto)
+      .expect(201)
+      .expect(res => {
+        expect(res.body.status).toBe('success');
+        expect(inventoryRepository.createInventory).toHaveBeenCalled();
+      });
+  });
+
+  it('POST /api/v1/inventory/update/:id', () => {
+    const dto: InventoryDTO = {
+      name: 'item',
+      description: 'desc',
+      unitOfMeasure: 'kg',
+      productId: 'prod',
+      costPrice: 5,
+      sellingPrice: 10,
+      productImage: 'img',
+      status: InventoryStatus.ACTIVE,
+      lowStockValue: 1,
+      quantityAvailable: 2,
+    };
+    inventoryRepository.updateInventory.mockResolvedValue({ _id: '1', ...dto });
+
+    return request(app.getHttpServer())
+      .post('/api/v1/inventory/update/1')
+      .send(dto)
+      .expect(201)
+      .expect(res => {
+        expect(res.body.status).toBe('success');
+        expect(inventoryRepository.updateInventory).toHaveBeenCalled();
+      });
+  });
+
+  it('GET /api/v1/inventory/get', () => {
+    const summary = { inventories: [], count: 0, numOfPages: 1, currentPage: 1 };
+    inventoryRepository.getAll.mockResolvedValue(summary);
+
+    return request(app.getHttpServer())
+      .get('/api/v1/inventory/get')
+      .expect(200)
+      .expect(res => {
+        expect(res.body.status).toBe('success');
+        expect(inventoryRepository.getAll).toHaveBeenCalled();
+      });
+  });
+});

--- a/test/inventory/inventory.service.spec.ts
+++ b/test/inventory/inventory.service.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InventoryService } from '../../src/inventory/inventory.service';
+import { InventoryRepository } from '../../src/inventory/schema/inventory.repository';
+import { ApiResponse } from '../../src/common/Helper/apiResponse';
+import { ActivityRepository } from '../../src/common/activity/activity.repository';
+import { InventoryDTO } from '../../src/inventory/dto/inventoryDto';
+import { InventoryStatus } from '../../src/inventory/enum/inventoryEnum';
+
+describe('InventoryService', () => {
+  let service: InventoryService;
+  let inventoryRepository: any;
+  let activityRepository: any;
+  let apiResponse: ApiResponse;
+  let res: any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InventoryService,
+        { provide: InventoryRepository, useValue: { createInventory: jest.fn(), updateInventory: jest.fn(), getAll: jest.fn() } },
+        { provide: ActivityRepository, useValue: { createActivity: jest.fn() } },
+        ApiResponse,
+      ],
+    }).compile();
+
+    service = module.get<InventoryService>(InventoryService);
+    inventoryRepository = module.get<InventoryRepository>(InventoryRepository);
+    activityRepository = module.get<ActivityRepository>(ActivityRepository);
+    apiResponse = module.get<ApiResponse>(ApiResponse);
+    res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  });
+
+  it('preparePayload should attach businessId', () => {
+    const body: InventoryDTO = {
+      name: 'item',
+      description: 'desc',
+      unitOfMeasure: 'kg',
+      productId: 'prod',
+      costPrice: 5,
+      sellingPrice: 10,
+      productImage: 'img',
+      status: InventoryStatus.ACTIVE,
+      lowStockValue: 1,
+      quantityAvailable: 2,
+    };
+    const payload = service.preparePayload('biz', body);
+    expect(payload).toEqual({
+      name: body.name,
+      description: body.description,
+      unitOfMeasure: body.unitOfMeasure,
+      productId: body.productId,
+      costPrice: body.costPrice,
+      sellingPrice: body.sellingPrice,
+      productImage: body.productImage,
+      status: body.status,
+      lowStockValue: body.lowStockValue,
+      quantityAvailable: body.quantityAvailable,
+      businessId: 'biz',
+    });
+  });
+
+  it('createInventory should create and return success', async () => {
+    const body: InventoryDTO = {
+      name: 'item',
+      description: 'desc',
+      unitOfMeasure: 'kg',
+      productId: 'prod',
+      costPrice: 5,
+      sellingPrice: 10,
+      productImage: 'img',
+      status: InventoryStatus.ACTIVE,
+      lowStockValue: 1,
+      quantityAvailable: 2,
+    };
+    const decoded = { sID: 'biz', userId: 'user' };
+    const created = { id: '1', ...body };
+    inventoryRepository.createInventory.mockResolvedValue(created);
+    jest.spyOn(apiResponse, 'success');
+    await service.createInventory(decoded, body, res);
+    expect(inventoryRepository.createInventory).toHaveBeenCalledWith(expect.objectContaining({ businessId: 'biz' }));
+    expect(activityRepository.createActivity).toHaveBeenCalled();
+    expect(apiResponse.success).toHaveBeenCalledWith(res, 'Inventory created successfully', created, 201);
+  });
+
+  it('updateInventory should update and return success', async () => {
+    const body: InventoryDTO = {
+      name: 'item',
+      description: 'desc',
+      unitOfMeasure: 'kg',
+      productId: 'prod',
+      costPrice: 5,
+      sellingPrice: 10,
+      productImage: 'img',
+      status: InventoryStatus.ACTIVE,
+      lowStockValue: 1,
+      quantityAvailable: 2,
+    };
+    const decoded = { sID: 'biz', userId: 'user' };
+    const updated = { id: '1', ...body };
+    inventoryRepository.updateInventory.mockResolvedValue(updated);
+    jest.spyOn(apiResponse, 'success');
+    await service.updateInventory(decoded, '1', body, res);
+    expect(inventoryRepository.updateInventory).toHaveBeenCalledWith({ _id: '1', businessId: 'biz' }, expect.any(Object));
+    expect(activityRepository.createActivity).toHaveBeenCalled();
+    expect(apiResponse.success).toHaveBeenCalledWith(res, 'Inventory created successfully', updated, 201);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `InventoryService`
- add e2e tests for inventory routes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:e2e` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68875a166f2c8332aa24bd4be2d99308