### PR TITLE
Add enums and extend Postman collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ npm run start:dev
 
 - `POST /api/v1/inventory/create` - Create a new inventory item
 - `PATCH /api/v1/inventory/update/:id` - Update an existing inventory item
+
+## Documentation
+
+Detailed API documentation is available in the [doc](doc/) directory. Import `doc/CropX.postman_collection.json` in Postman to try the endpoints.

--- a/doc/CropX.postman_collection.json
+++ b/doc/CropX.postman_collection.json
@@ -1,0 +1,131 @@
+{
+  "info": {
+    "name": "CropX API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "API examples for CropX backend"
+  },
+  "variable": [
+    {"key": "base_url", "value": "http://localhost:3000"}
+  ],
+  "item": [
+    {
+      "name": "Inventory",
+      "description": "Manage farm inventories",
+      "item": [
+        {
+          "name": "List Inventories",
+          "request": {"method": "GET", "url": "{{base_url}}/api/v1/inventory/get"}
+        },
+        {"name": "Get Inventory",
+          "request": {"method": "GET", "url": "{{base_url}}/api/v1/inventory/get/:id"}
+        },
+        {"name": "Create Inventory",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw": "{\n  \"name\": \"Tomatoes\",\n  \"quantity\": 100,\n  \"unit\": \"kg\"\n}"},
+            "url": "{{base_url}}/api/v1/inventory/create"
+          }
+        },
+        {"name": "Update Inventory",
+          "request": {
+            "method": "PATCH",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw": "{\n  \"name\": \"Tomatoes\"\n}"},
+            "url": "{{base_url}}/api/v1/inventory/update/:id"
+          }
+        },
+        {"name": "Delete Inventory",
+          "request": {"method": "DELETE", "url": "{{base_url}}/api/v1/inventory/delete/:id"}
+        },
+        {"name": "Inventory Summary",
+          "request": {"method": "GET", "url": "{{base_url}}/api/v1/inventory/summary"}
+        }
+      ]
+    },
+    {
+      "name": "Customer",
+      "item": [
+        {"name": "List Customers", "request": {"method": "GET", "url": "{{base_url}}/api/v1/customer/get"}},
+        {"name": "Get Customer", "request": {"method": "GET", "url": "{{base_url}}/api/v1/customer/get/:id"}},
+        {"name": "Create Customer",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw": "{\n  \"name\": \"John Doe\",\n  \"phone\": \"+234111111111\",\n  \"email\": \"john@example.com\"\n}"},
+            "url": "{{base_url}}/api/v1/customer/create"
+          }
+        },
+        {"name": "Update Customer",
+          "request": {
+            "method": "POST",
+            "header": [{"key":"Content-Type","value":"application/json"}],
+            "body": {"mode":"raw","raw": "{}"},
+            "url": "{{base_url}}/api/v1/customer/update/:id"
+          }
+        },
+        {"name": "Delete Customer", "request": {"method": "DELETE", "url": "{{base_url}}/api/v1/customer/delete/:id"}}
+      ]
+    },
+    {
+      "name": "User & Auth",
+      "item": [
+        {"name": "Register", "request": {"method": "POST", "header":[{"key":"Content-Type","value":"application/json"}], "body":{"mode":"raw","raw":"{\n  \"email\": \"user@example.com\",\n  \"password\": \"secret\"\n}"}, "url": "{{base_url}}/api/v1/auth/create"}},
+        {"name": "Login", "request": {"method": "POST", "header":[{"key":"Content-Type","value":"application/json"}], "body":{"mode":"raw","raw":"{\n  \"email\": \"user@example.com\",\n  \"password\": \"secret\"\n}"}, "url": "{{base_url}}/api/v1/auth/login"}},
+        {"name": "Create PIN", "request": {"method": "POST", "url": "{{base_url}}/api/v1/auth/create-pin"}},
+        {"name": "Verify PIN", "request": {"method": "POST", "url": "{{base_url}}/api/v1/auth/verify-pin"}},
+        {"name": "User Profile", "request": {"method": "GET", "url": "{{base_url}}/api/v1/auth/user"}}
+      ]
+    },
+    {
+      "name": "Invoice",
+      "item": [
+        {"name": "List Invoices", "request": {"method": "GET", "url": "{{base_url}}/api/v1/invoice/get"}},
+        {"name": "Get Invoice", "request": {"method": "GET", "url": "{{base_url}}/api/v1/invoice/get/:id"}},
+        {"name": "Create Invoice", "request": {"method": "POST", "header":[{"key":"Content-Type","value":"application/json"}], "body":{"mode":"raw","raw":"{\n  \"title\": \"Produce Sale\",\n  \"amount\": 5000,\n  \"customerId\": \"<id>\"\n}"}, "url": "{{base_url}}/api/v1/invoice/create"}},
+        {"name": "Delete Invoice", "request": {"method": "DELETE", "url": "{{base_url}}/api/v1/invoice/delete/:id"}},
+        {"name": "Pay Invoice", "request": {"method": "POST", "url": "{{base_url}}/api/v1/invoice/payment"}}
+      ]
+    },
+    {
+      "name": "Products & News",
+      "item": [
+        {"name": "List Products", "request": {"method": "GET", "url": "{{base_url}}/api/v1/products/inc"}},
+        {"name": "Get Product", "request": {"method": "GET", "url": "{{base_url}}/api/v1/products/inc/:id"}},
+        {"name": "Create Product", "request": {"method": "POST", "header":[{"key":"Content-Type","value":"application/json"}], "body":{"mode":"raw","raw":"{\n  \"name\": \"Wheat\",\n  \"description\": \"grains\",\n  \"status\": \"ACTIVE\"\n}"}, "url": "{{base_url}}/api/v1/products/inc"}},
+        {"name": "Update Product", "request": {"method": "PATCH", "url": "{{base_url}}/api/v1/products/inc"}},
+        {"name": "Create News", "request": {"method": "POST", "url": "{{base_url}}/api/v1/products/news"}},
+        {"name": "List News", "request": {"method": "GET", "url": "{{base_url}}/api/v1/products/news"}},
+        {"name": "Get News", "request": {"method": "GET", "url": "{{base_url}}/api/v1/products/news/:id"}},
+        {"name": "Update News", "request": {"method": "PATCH", "url": "{{base_url}}/api/v1/products/news"}},
+        {"name": "Subscribe", "request": {"method": "POST", "url": "{{base_url}}/api/v1/products/subscription"}},
+        {"name": "Unsubscribe", "request": {"method": "DELETE", "url": "{{base_url}}/api/v1/products/subscription"}},
+        {"name": "Price List", "request": {"method": "GET", "url": "{{base_url}}/api/v1/products/prices"}},
+        {"name": "Create Price", "request": {"method": "POST", "url": "{{base_url}}/api/v1/products/prices"}},
+        {"name": "Get Price", "request": {"method": "GET", "url": "{{base_url}}/api/v1/products/prices/:id"}},
+        {"name": "Update Price", "request": {"method": "PATCH", "url": "{{base_url}}/api/v1/products/price"}},
+        {"name": "Price Graph", "request": {"method": "GET", "url": "{{base_url}}/api/v1/products/prices/graph/:id"}}
+      ]
+    },
+    {
+      "name": "Wallets",
+      "item": [
+        {"name": "Create Wallet", "request": {"method": "POST", "url": "{{base_url}}/api/v1/wallets"}},
+        {"name": "Get Wallet", "request": {"method": "GET", "url": "{{base_url}}/api/v1/wallets"}},
+        {"name": "Get Card", "request": {"method": "GET", "url": "{{base_url}}/api/v1/wallets/card"}},
+        {"name": "Request Card Holder", "request": {"method": "POST", "url": "{{base_url}}/api/v1/wallets/card/holder"}},
+        {"name": "Link Card", "request": {"method": "POST", "url": "{{base_url}}/api/v1/wallets/card/link"}},
+        {"name": "Transactions", "request": {"method": "GET", "url": "{{base_url}}/api/v1/wallets/transactions"}},
+        {"name": "Transfer", "request": {"method": "POST", "url": "{{base_url}}/api/v1/wallets/transfer"}},
+        {"name": "Freeze Card", "request": {"method": "POST", "url": "{{base_url}}/api/v1/wallets/freeze-card"}}
+      ]
+    },
+    {
+      "name": "Storage",
+      "item": [
+        {"name": "Upload File", "request": {"method": "POST", "url": "{{base_url}}/storage/upload"}},
+        {"name": "Get File", "request": {"method": "GET", "url": "{{base_url}}/storage/:filename"}}
+      ]
+    }
+  ]
+}

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,14 @@
+# CropX Backend Documentation
+
+This directory contains documentation for CropX Backend APIs and development workflow.
+
+- [Inventory](inventory.md)
+- [Customer](customer.md)
+- [User & Auth](user.md)
+- [Invoicing](invoice.md)
+- [Product & News](product-news.md)
+- [Cards & Wallets](cards.md)
+- [Storage](storage.md)
+- [Enumerations](enums.md)
+
+Import `CropX.postman_collection.json` in Postman to try the endpoints. The collection uses `{{base_url}}` so you can easily switch between environments.

--- a/doc/cards.md
+++ b/doc/cards.md
@@ -1,0 +1,31 @@
+# Cards & Wallets API
+
+Base URL: `/api/v1/wallets`
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| POST | `/` | Create wallet for user |
+| GET  | `/` | Get wallet information |
+| GET | `/card` | Get linked card |
+| GET | `/requested-card` | Get card request status |
+| GET | `/card-pin` | Retrieve default card pin |
+| POST | `/card/holder` | Request card holder creation |
+| POST | `/card/link` | Link a physical card |
+| GET | `/transactions` | List wallet transactions |
+| GET | `/transaction/:id` | Get single transaction |
+| POST | `/transfer` | Transfer funds between wallets |
+| POST | `/freeze-card` | Freeze or unfreeze card |
+
+Admin routes under `/admin/*` allow management of wallets and card requests.
+
+### Enums
+- `CardDeliveryStatus`: Pending, Dispatched, Delivered, Linked
+- `BankName`: Safe Have MFB, Guaranty Trust Bank, Providus Bank
+
+### Example: Transfer Funds
+```json
+{
+  "amount": 2000,
+  "toAccount": "1234567890"
+}
+```

--- a/doc/customer.md
+++ b/doc/customer.md
@@ -1,0 +1,20 @@
+# Customer API
+
+Base URL: `/api/v1/customer`
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| POST | `/create` | Create a new customer for the business |
+| GET | `/get` | List customers for the authenticated business |
+| GET | `/get/:id` | Retrieve a single customer |
+| POST | `/update/:id` | Update customer details |
+| DELETE | `/delete/:id` | Remove a customer record |
+
+### Sample Payload
+```json
+{
+  "name": "John Doe",
+  "phone": "+234111111111",
+  "email": "john@example.com"
+}
+```

--- a/doc/enums.md
+++ b/doc/enums.md
@@ -1,0 +1,26 @@
+# API Enumerations
+
+This document lists the important enum values used across the CropX backend. They are useful when calling the API or exploring the Postman collection.
+
+## User Module
+- `UserRole`: `Admin`, `User`, `Company`
+- `UserStatus`: `Suspended`, `Active`, `Inactive`
+- `AdminRole`: `SuperAdmin`, `Accountant`, `ITSupport`, `CustomerSupport`, `Viewer`, `Blogger`
+
+## Inventory Module
+- `InventoryStatus`: `ACTIVE`, `INACTIVE`, `OUTOFSTOCK`
+
+## Invoice Module
+- `InvoiceStatus`: `Pending`, `Overdue`, `Settled`
+
+## Card & Wallet Module
+- `CardDeliveryStatus`: `Pending`, `Dispatched`, `Delivered`, `Linked`
+- `BankName`: `Safe Have MFB`, `Guaranty Trust Bank`, `Provudis Bank`
+- `StatusEnum`: `active`, `inactive`
+
+## Transaction Module
+- `TransactionType`: `INCOME`, `EXPENSE`
+- `TransactionSubType`: `SALES`, `STOCK`, `USAGE`, `DESTROYED`
+- `TransactionStatus`: `SETTLED`, `INACTIVE`, `OUTOFSTOCK`
+
+These enums provide context for certain request or response fields. Refer to the service source code for full definitions.

--- a/doc/inventory.md
+++ b/doc/inventory.md
@@ -1,0 +1,26 @@
+# Inventory API
+
+Base URL: `/api/v1/inventory`
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/get` | Retrieve paginated inventories for the authenticated user |
+| GET | `/get/:id` | Retrieve a single inventory item |
+| DELETE | `/delete/:id` | Delete an inventory item |
+| POST | `/create` | Create a new inventory item |
+| PATCH | `/update/:id` | Update an inventory item |
+| GET | `/summary` | Get summary statistics for inventories |
+
+Admin endpoints exist under `/admin/*` for managing inventories across users.
+
+### Enums
+- `InventoryStatus`: ACTIVE, INACTIVE, OUTOFSTOCK
+
+### Sample Payload
+```json
+{
+  "name": "Tomatoes",
+  "quantity": 100,
+  "unit": "kg"
+}
+```

--- a/doc/invoice.md
+++ b/doc/invoice.md
@@ -1,0 +1,24 @@
+# Invoice API
+
+Base URL: `/api/v1/invoice`
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| POST | `/payment` | Initiate invoice payment |
+| POST | `/transfer` | Receive transfer webhook |
+| GET | `/get` | List invoices for the user |
+| GET | `/get/:id` | Retrieve a single invoice |
+| DELETE | `/delete/:id` | Delete an invoice |
+| POST | `/create` | Create a new invoice |
+
+### Enums
+- `InvoiceStatus`: Pending, Overdue, Settled
+
+### Invoice Creation Payload
+```json
+{
+  "title": "Produce Sale",
+  "amount": 5000,
+  "customerId": "<id>"
+}
+```

--- a/doc/product-news.md
+++ b/doc/product-news.md
@@ -1,0 +1,36 @@
+# Product & News API
+
+Base URL: `/api/v1/products`
+
+This module manages products, news posts and daily prices.
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| POST | `/inc` | Create a product (admin only) |
+| GET | `/inc` | List products |
+| GET | `/inc/:id` | Get a single product |
+| PATCH | `/inc` | Update product status (admin only) |
+| POST | `/news` | Create product news |
+| GET | `/news` | List news items |
+| GET | `/news/:id` | Get a single news post |
+| PATCH | `/news` | Update news post |
+| POST | `/subscription` | Subscribe to product updates |
+| DELETE | `/subscription` | Remove subscription |
+| GET | `/prices` | List daily prices |
+| POST | `/prices` | Create daily price |
+| GET | `/prices/:id` | Get a price record |
+| PATCH | `/price` | Update price |
+| GET | `/prices/graph/:id` | Graph data for product price |
+
+### Enums
+- `TransactionType`: INCOME, EXPENSE
+- `TransactionSubType`: SALES, STOCK, USAGE, DESTROYED
+
+### Example: Create Product
+```json
+{
+  "name": "Wheat",
+  "description": "grains",
+  "status": "ACTIVE"
+}
+```

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -1,0 +1,13 @@
+# Storage API
+
+Base URL: `/storage`
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| POST | `/upload` | Upload a file to Cloudinary |
+| GET | `/:filename` | Retrieve a stored file |
+
+### Example cURL
+```bash
+curl -F "file=@path/to/image.png" http://localhost:3000/storage/upload
+```

--- a/doc/user.md
+++ b/doc/user.md
@@ -1,0 +1,32 @@
+# User & Authentication API
+
+Base URL: `/api/v1/auth`
+
+Key endpoints include:
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| POST | `/create` | Register a new user |
+| POST | `/login` | Login and obtain auth token |
+| GET | `/user` | Get profile of authenticated user |
+| POST | `/verify-pin` | Verify transaction pin |
+| POST | `/create-pin` | Create transaction pin |
+| POST | `/reset-password` | Request password reset |
+| POST | `/new-password` | Complete password reset |
+| PATCH | `/business/:businessId` | Update a business |
+| GET | `/business` | List businesses for the user |
+| PATCH | `/user` | Update user details |
+
+More administration endpoints exist for creating admins, blocking users and managing roles.
+
+### Enums
+- `UserRole`: Admin, User, Company
+- `UserStatus`: Suspended, Active, Inactive
+
+### Sample Login Payload
+```json
+{
+  "email": "user@example.com",
+  "password": "secret"
+}
+```


### PR DESCRIPTION
## Summary
- document enums used across modules
- expand docs for cards, user, inventory, invoice and products
- overhaul Postman collection with more endpoints and `{{base_url}}` variable

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887627b90f48332a333b76833378a61