### PR TITLE
Add monitored price scraping support

### DIFF
--- a/src/common/services/openai.service.ts
+++ b/src/common/services/openai.service.ts
@@ -29,4 +29,12 @@ export class OpenAIService {
     });
     return image.data?.[0]?.url || '';
   }
+
+  /**
+   * Performs a generic chat completion request. Returns the raw message content.
+   */
+  async chat(params: OpenAI.Chat.ChatCompletionCreateParams): Promise<string> {
+    const completion = await this.openai.chat.completions.create(params);
+    return completion.choices[0].message?.content?.trim() || '';
+  }
 }

--- a/src/product-news/dto/product.dto.ts
+++ b/src/product-news/dto/product.dto.ts
@@ -3,6 +3,7 @@ import {
   IsBoolean,
   IsMongoId,
   IsObject,
+  IsOptional,
   IsString,
 } from 'class-validator';
 import { Types } from 'mongoose';
@@ -21,6 +22,10 @@ export class NewProductDto {
   productLocation: string;
 
   availabilityStatus: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  isMonitored?: boolean;
 
   @IsString()
   unitOfMeasure: string;

--- a/src/product-news/interface/product.interface.ts
+++ b/src/product-news/interface/product.interface.ts
@@ -6,6 +6,7 @@ export class ProductInterface extends Document {
   productImage: string;
   productLocation: string;
   availabilityStatus: boolean;
+  isMonitored: boolean;
 }
 
 export class ProductNewsInterface extends Document {

--- a/src/product-news/internal/cron.ts
+++ b/src/product-news/internal/cron.ts
@@ -1,13 +1,59 @@
 import { Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ProductRepository } from '../schema/product.repository';
+import { ProductScraperService } from '../scraper.service';
 
 @Injectable()
 export class CronJob {
-  constructor(private productRepository: ProductRepository) {}
+  constructor(
+    private productRepository: ProductRepository,
+    private scraper: ProductScraperService,
+  ) {}
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
-  handleNewProductPrice() {
+  async handleNewProductPrice() {
     console.log('Treating new Product price');
-    this.productRepository.setDailyProductPrice();
+    await this.productRepository.setDailyProductPrice();
+
+    const html = process.env.AFRICA_EXCHANGE_HTML;
+    if (!html) return;
+
+    try {
+      const scraped = await this.scraper.fetchPricesFromHtml(html);
+      for (const item of scraped) {
+        const product = await this.productRepository.getSingleProduct({
+          commonName: item.commonName,
+        });
+        if (product?.isMonitored) {
+          await this.productRepository.upsertTodayPrice(
+            product._id,
+            item.currentPrice,
+          );
+        }
+      }
+    } catch (err) {
+      console.error('Failed to update monitored prices', err);
+    }
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_1AM)
+  async refreshProducts() {
+    try {
+      // Provide HTML via env var if network is disabled
+      const html = process.env.AFRICA_EXCHANGE_HTML;
+      if (!html) {
+        console.warn('AFRICA_EXCHANGE_HTML not provided; skipping scrape');
+        return;
+      }
+      const products = await this.scraper.fetchProductsFromHtml(html);
+      for (const p of products) {
+        const saved = await this.productRepository.addProduct({
+          ...p,
+          isMonitored: true,
+        });
+        await this.productRepository.upsertTodayPrice(saved._id, p.currentPrice);
+      }
+    } catch (err) {
+      console.error('Failed to refresh products', err);
+    }
   }
 }

--- a/src/product-news/product-news.module.ts
+++ b/src/product-news/product-news.module.ts
@@ -22,6 +22,8 @@ import { ProductsNewsController } from './product-news.controller';
 import { ProductsNewsService } from './product-news.service';
 import { AiNewsService } from './ai-news.service';
 import { OpenAIService } from '../common/services/openai.service';
+import { ProductScraperService } from './scraper.service';
+import { CronJob } from './internal/cron';
 
 @Module({
   imports: [
@@ -39,6 +41,8 @@ import { OpenAIService } from '../common/services/openai.service';
     ImageStorage,
     OpenAIService,
     AiNewsService,
+    ProductScraperService,
+    CronJob,
   ],
 })
 export class ProductsNewsModule {

--- a/src/product-news/schema/product.repository.ts
+++ b/src/product-news/schema/product.repository.ts
@@ -332,6 +332,30 @@ export class ProductRepository {
     return this.productSubscriptionModel.deleteOne(search).exec();
   }
 
+  /**
+   * Creates or updates today's price entry for a product.
+   */
+  async upsertTodayPrice(productId: Types.ObjectId, price: number) {
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const existing = await this.productDailyPriceModel.findOne({
+      product: productId,
+      createdAt: { $gte: startOfDay },
+    });
+
+    if (existing) {
+      existing.currentPrice = price;
+      await existing.save();
+      return existing;
+    }
+
+    return await new this.productDailyPriceModel({
+      product: productId,
+      currentPrice: price,
+    }).save();
+  }
+
   async setDailyProductPrice() {
     const today = new Date();
     const yesterday = new Date(today);

--- a/src/product-news/schema/product.schema.ts
+++ b/src/product-news/schema/product.schema.ts
@@ -18,6 +18,11 @@ export class Product {
   @Prop({ type: Boolean, default: true })
   availabilityStatus: boolean;
 
+  // Indicates if this product was scraped from an external source and should
+  // be monitored for daily price updates automatically
+  @Prop({ type: Boolean, default: false })
+  isMonitored: boolean;
+
   @Prop({ type: String, required: true })
   productDescription: string;
 
@@ -55,10 +60,11 @@ export class ProductNews {
 }
 
 export const ProductNewsSchema = SchemaFactory.createForClass(ProductNews);
+ProductNewsSchema.index({ product: 1, createdAt: -1 });
 
 @Schema({ timestamps: true, collection: 'product_daily_prices' })
 export class ProductDailyPrices {
-  @Prop({ type: Types.ObjectId, ref: 'Product', required: true })
+  @Prop({ type: Types.ObjectId, ref: 'Product', required: true, index: true })
   product: Types.ObjectId;
 
   @Prop({
@@ -77,6 +83,9 @@ export class ProductDailyPrices {
 export const ProductDailyPricesSchema =
   SchemaFactory.createForClass(ProductDailyPrices);
 
+// Index to quickly fetch prices for a product ordered by creation date
+ProductDailyPricesSchema.index({ product: 1, createdAt: -1 });
+
 ProductDailyPricesSchema.set('toObject', { getters: true });
 ProductDailyPricesSchema.set('toJSON', { getters: true });
 
@@ -94,3 +103,4 @@ export class ProductSubscription {
 
 export const ProductSubscriptionSchema =
   SchemaFactory.createForClass(ProductSubscription);
+ProductSubscriptionSchema.index({ userId: 1, product: 1 });

--- a/src/product-news/scraper.service.ts
+++ b/src/product-news/scraper.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
+import { OpenAIService } from '../common/services/openai.service';
+import { NewProductDto } from './dto/product.dto';
+
+/**
+ * Service responsible for extracting product data from external sources.
+ * The environment running this code might not have outbound network access.
+ * If network access is blocked, provide the HTML content manually when calling
+ * fetchProductsFromHtml().
+ */
+@Injectable()
+export class ProductScraperService {
+  private readonly logger = new Logger(ProductScraperService.name);
+
+  constructor(private readonly openai: OpenAIService) {}
+
+  /**
+   * Attempts to download HTML from the given URL and extract product data using OpenAI.
+   * Will throw if HTTP requests are not allowed in the execution environment.
+   */
+  async fetchProductsFromUrl(url: string): Promise<NewProductDto[]> {
+    const resp = await axios.get(url);
+    return this.fetchProductsFromHtml(resp.data);
+  }
+
+  /**
+   * Uses OpenAI to parse raw HTML and return a list of products conforming to NewProductDto.
+   */
+  async fetchProductsFromHtml(html: string): Promise<(NewProductDto & { currentPrice: number })[]> {
+    const completion = await this.openai.chat({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Extract all product information from the following HTML. ' +
+            'Return JSON array of objects with fields: productName, commonName, productImage, productLocation, unitOfMeasure, currentPrice.\n' +
+            html,
+        },
+      ],
+    });
+
+    try {
+      const data = JSON.parse(completion);
+      return Array.isArray(data)
+        ? (data as (NewProductDto & { currentPrice: number })[])
+        : [];
+    } catch (err) {
+      this.logger.error('Failed to parse OpenAI response', err);
+      return [];
+    }
+  }
+
+  /**
+   * Extracts just the current price for products from raw HTML. Returns an array
+   * of objects containing commonName and currentPrice.
+   */
+  async fetchPricesFromHtml(html: string): Promise<{ commonName: string; currentPrice: number }[]> {
+    const completion = await this.openai.chat({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'user',
+          content:
+            'From the following HTML extract product common name and price in naira. ' +
+            'Return JSON array of objects with fields: commonName and currentPrice.\n' +
+            html,
+        },
+      ],
+    });
+
+    try {
+      const data = JSON.parse(completion);
+      return Array.isArray(data)
+        ? (data as { commonName: string; currentPrice: number }[])
+        : [];
+    } catch (err) {
+      this.logger.error('Failed to parse OpenAI response', err);
+      return [];
+    }
+  }
+
+  /**
+   * Generates an image URL for a given product using OpenAI's image generation API.
+   */
+  async generateProductImage(prompt: string): Promise<string> {
+    return this.openai.generateImage(prompt);
+  }
+}


### PR DESCRIPTION
## Summary
- support tracking scraped products by adding an `isMonitored` flag
- parse product prices from HTML using OpenAI
- record initial prices and mark products monitored on scrape
- update daily cron job to refresh monitored prices from the HTML source
- provide repository helper to upsert today's price entry

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876b215034833287d1983036a739dd