### PR TITLE
Fix TypeScript openai return type

### DIFF
--- a/src/common/services/openai.service.ts
+++ b/src/common/services/openai.service.ts
@@ -15,8 +15,10 @@ export class OpenAIService {
       model: 'gpt-4o',
       messages: [{ role: 'user', content: `Summarize this news:\n${text}` }],
       max_tokens: 200,
+      stream: false,
     });
-    return completion.choices[0].message?.content?.trim() || '';
+    const result = completion as OpenAI.Chat.ChatCompletion;
+    return result.choices[0].message?.content?.trim() || '';
   }
 
   async generateImage(prompt: string): Promise<string> {
@@ -34,7 +36,11 @@ export class OpenAIService {
    * Performs a generic chat completion request. Returns the raw message content.
    */
   async chat(params: OpenAI.Chat.ChatCompletionCreateParams): Promise<string> {
-    const completion = await this.openai.chat.completions.create(params);
-    return completion.choices[0].message?.content?.trim() || '';
+    const completion = await this.openai.chat.completions.create({
+      ...params,
+      stream: false,
+    });
+    const result = completion as OpenAI.Chat.ChatCompletion;
+    return result.choices[0].message?.content?.trim() || '';
   }
 }


### PR DESCRIPTION
## Summary
- fix `choices` type error in `OpenAIService`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688773d6c2448332986cc661ae088c4e