### PR TITLE
Add transaction pin verification

### DIFF
--- a/doc/cards.md
+++ b/doc/cards.md
@@ -25,7 +25,10 @@ Admin routes under `/admin/*` allow management of wallets and card requests.
 ### Example: Transfer Funds
 ```json
 {
+  "nameEnquiryReference": "ref123",
+  "beneficiaryBankCode": "000",
+  "beneficiaryAccountNumber": "1234567890",
   "amount": 2000,
-  "toAccount": "1234567890"
+  "pin": "1234"
 }
 ```

--- a/doc/user.md
+++ b/doc/user.md
@@ -11,6 +11,8 @@ Key endpoints include:
 | GET | `/user` | Get profile of authenticated user |
 | POST | `/verify-pin` | Verify transaction pin |
 | POST | `/create-pin` | Create transaction pin |
+| POST | `/add-pin` | Set transaction pin on user record |
+| POST | `/change-pin` | Change existing transaction pin |
 | POST | `/reset-password` | Request password reset |
 | POST | `/new-password` | Complete password reset |
 | PATCH | `/business/:businessId` | Update a business |

--- a/src/cards/cards.controller.ts
+++ b/src/cards/cards.controller.ts
@@ -58,8 +58,9 @@ export class CardsController {
   @UseGuards(UserRolesGuard)
   @Roles('User', 'Company')
   transferFund(@Body() body: TransferDto, @Req() req) {
-    const { sID, membershipId } = req.decoded;
-    return this.cardService.transfer(sID, body);
+    const { sID } = req.decoded;
+    const user = req.user;
+    return this.cardService.transfer(sID, body, user);
   }
 
   @Post('card/holder')

--- a/src/cards/dto/card.dto.ts
+++ b/src/cards/dto/card.dto.ts
@@ -1,4 +1,4 @@
-import { IsMongoId, IsNotEmpty, IsNumber,ValidateNested,IsObject, IsEnum, IsNumberString, IsString, IsOptional } from 'class-validator'
+import { IsMongoId, IsNotEmpty, IsNumber,ValidateNested,IsObject, IsEnum, IsNumberString, IsString, IsOptional, MinLength, MaxLength } from 'class-validator'
 import { Types } from 'mongoose';
 import { Type } from 'class-transformer';
 import { StatusEnum } from '../interface/card.enum';
@@ -29,6 +29,11 @@ export class TransferDto {
     narration?: string;
     @IsNumber()
     amount: number;
+
+    @IsNumberString()
+    @MinLength(4)
+    @MaxLength(4)
+    pin: string;
 }
 
 class UserDataDto {


### PR DESCRIPTION
## Summary
- introduce `pin` field for wallet transfers
- require user pin verification in `transfer` service
- document new pin-based transfer request
- document `/add-pin` and `/change-pin` endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889ed685a588332883b5b94356e1753